### PR TITLE
Support to Android sources and javadoc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,10 @@ plugins {
 }
 
 group = "tech.medivh"
-version = "1.2.3"
+version = "1.2.4"
 
 repositories {
+    google()
     mavenLocal()
     mavenCentral()
 }
@@ -20,6 +21,8 @@ dependencies {
     val jacksonVersion: String by versions
     val okhttpVersion: String by versions
     val jgitVersion: String by versions
+    val agp: String by versions
+    implementation("com.android.tools.build:gradle:${agp}")
     implementation("com.squareup.okhttp3:okhttp:${okhttpVersion}")
     implementation("org.eclipse.jgit:org.eclipse.jgit:${jgitVersion}")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:${jacksonVersion}")

--- a/src/main/kotlin/tech/medivh/plugin/gradle/publisher/process/AndroidProcessFlow.kt
+++ b/src/main/kotlin/tech/medivh/plugin/gradle/publisher/process/AndroidProcessFlow.kt
@@ -1,5 +1,7 @@
 package tech.medivh.plugin.gradle.publisher.process
 
+
+import com.android.build.gradle.LibraryExtension
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPublication
 import tech.medivh.plugin.gradle.publisher.MedivhPublisherExtension
@@ -20,9 +22,9 @@ class AndroidProcessFlow : ProcessFlow {
 
 
     override fun setArtifacts(mavenPublication: MavenPublication, project: Project) {
-        mavenPublication.artifact(
-            project.layout.buildDirectory.dir("outputs/aar/${project.name}-release.aar").get().asFile.path
-        )
+        project.extensions.findByType(LibraryExtension::class.java).also {
+            mavenPublication.from(project.components.getByName("release"))
+        } ?: throw IllegalStateException("Android Library Plugin not applied")
     }
 
     override fun defaultGroupId(mavenPublication: MavenPublication, project: Project): String {

--- a/versions.properties
+++ b/versions.properties
@@ -1,3 +1,4 @@
 jgitVersion=7.0.0.202409031743-r
 jacksonVersion=2.15.2
 okhttpVersion=4.12.0
+agp=7.0.0


### PR DESCRIPTION
Hello, this is such a great project!
I made some changes to allow upload sourcesJar and JavaDocs for Android Projects

- Updated plugin version to 1.2.4
- Added google() repository
- Added Android Gradle Plugin (AGP) dependency
- Updated Android artifact publishing to use "release" component

For my specific project, works like a charm! I hope that would be useful for someone else
<img width="1231" alt="Captura de tela 2025-05-15 225248" src="https://github.com/user-attachments/assets/71ab68e6-6597-4ed8-8961-956ddacf2819" />
